### PR TITLE
Modified ElasticFetcher to run multiple searches of index specific duration

### DIFF
--- a/multiversx_usage_analytics_tool/elastic_fetcher.py
+++ b/multiversx_usage_analytics_tool/elastic_fetcher.py
@@ -1,13 +1,14 @@
 from typing import Any, Dict, List
 
 from elastic_transport._response import ObjectApiResponse
-from indexer import Indexer
 
 from multiversx_usage_analytics_tool.constants import DEFAULT_DATE
 from multiversx_usage_analytics_tool.ecosystem import Organization
 from multiversx_usage_analytics_tool.fetcher import (DailyActivity, Fetcher,
                                                      Package)
-from multiversx_usage_analytics_tool.utils import (FormattedDate, Indexes, Reports,
+from multiversx_usage_analytics_tool.indexer import Indexer
+from multiversx_usage_analytics_tool.utils import (FormattedDate, Index,
+                                                   Indexes, Reports,
                                                    UserAgentGroups,
                                                    get_environment_var)
 
@@ -45,11 +46,11 @@ class ElasticSearchFetcher(Fetcher):
     def get_package(self, item: Dict[str, Any]) -> ElasticSearchPackage:
         return ElasticSearchPackage.from_generated_file(item)
 
-    def get_user_agent_aggregate_packages(self, response: ObjectApiResponse[Any]) -> List[ElasticSearchPackage]:
-        raw_downloads = response.get("aggregations", {}).get("user_agents", {}).get("buckets", [])
+    def get_user_agent_aggregate_packages(self, response: dict[str, Any]) -> List[ElasticSearchPackage]:
+        raw_downloads = [response[key] for key in response.keys()]  # response.get("aggregations", {}).get("user_agents", {}).get("buckets", [])
         return [ElasticSearchPackage.from_aggregate_elastic_search(item) for item in raw_downloads]
 
-    def fetch_aggregate_data(self, end_date: str) -> ObjectApiResponse[Any]:
+    def fetch_aggregate_data(self, end_date: str) -> dict[str, Any]:
         indexer = Indexer(
             get_environment_var('ELASTIC_SEARCH_LOGS_URL'),
             get_environment_var('ELASTIC_SEARCH_USER'),
@@ -57,13 +58,33 @@ class ElasticSearchFetcher(Fetcher):
         )
 
         end_timestamp = FormattedDate.from_string(end_date)
-        start_timestamp = end_timestamp - Reports.YELLOW.value.repo_length + 1
+        indexes = [Indexes.INGRESS]
+        fetch_dict = {}
+        for index in indexes:
+            fetch_start_date = end_timestamp - index.value.days_to_fetch_in_one_go + 1
 
-        index = get_environment_var(Indexes.INGRESS.value.index_name)
-        count = indexer.count_records(index, start_timestamp, end_timestamp)
-        print(f'fetching from {self.organization.name} access logs - {count} documents...')
+            while fetch_start_date > FormattedDate.from_string(self.start_date) - 1:
+                resp = self.fetch_data(indexer, index.value, end_timestamp)
+                end_timestamp -= index.value.days_to_fetch_in_one_go
+                fetch_start_date -= index.value.days_to_fetch_in_one_go
 
-        resp = indexer.get_aggregate_records(index, start_timestamp=start_timestamp, end_timestamp=end_timestamp)
+                # merge the results
+                for entry in resp.get("aggregations", {}).get("user_agents", {}).get("buckets", []):
+                    key = entry.get('key', '')
+                    if key not in fetch_dict.keys():
+                        fetch_dict[key] = entry
+                    else:
+                        fetch_dict[key]['doc_count'] += entry['doc_count']
+                        fetch_dict[key]['docs_per_day']['buckets'] += entry['docs_per_day']['buckets']
+        return fetch_dict
+
+    def fetch_data(self, indexer: Indexer, index: Index, end_timestamp: FormattedDate) -> ObjectApiResponse[Any]:
+        index_name = get_environment_var(index.index_name)
+        start_timestamp = end_timestamp - index.days_to_fetch_in_one_go + 1
+        count = indexer.count_records(index_name, start_timestamp, end_timestamp)
+        print(f'fetching from {self.organization.name} {index.index_title} ({start_timestamp} - {end_timestamp}) = {count} documents...')
+        resp = indexer.get_aggregate_records(index_name, start_timestamp=start_timestamp, end_timestamp=end_timestamp)
+
         return resp
 
     def get_user_agent_grouped_packages(self, raw_packages: List[ElasticSearchPackage]) -> List[ElasticSearchPackage]:

--- a/multiversx_usage_analytics_tool/elastic_fetcher.py
+++ b/multiversx_usage_analytics_tool/elastic_fetcher.py
@@ -47,7 +47,7 @@ class ElasticSearchFetcher(Fetcher):
         return ElasticSearchPackage.from_generated_file(item)
 
     def get_user_agent_aggregate_packages(self, response: dict[str, Any]) -> List[ElasticSearchPackage]:
-        raw_downloads = [response[key] for key in response.keys()]  # response.get("aggregations", {}).get("user_agents", {}).get("buckets", [])
+        raw_downloads = [response[key] for key in response.keys()]
         return [ElasticSearchPackage.from_aggregate_elastic_search(item) for item in raw_downloads]
 
     def fetch_aggregate_data(self, end_date: str) -> dict[str, Any]:

--- a/multiversx_usage_analytics_tool/utils.py
+++ b/multiversx_usage_analytics_tool/utils.py
@@ -33,18 +33,19 @@ class Report:
 class Reports (Enum):
     BLUE = Report('blue', 'PACKAGE MANAGERS REPORT', '#e6f7ff', BLUE_REPORT_PORT, DAYS_IN_MONTHLY_REPORT)
     GREEN = Report('green', 'GITHUB REPORT', '#e6ffe6', GREEN_REPORT_PORT, DAYS_IN_TWO_WEEKS_REPORT)
-    YELLOW = Report('yellow', 'USER AGENT REPORT', '#FFFFF0', YELLOW_REPORT_PORT, DAYS_IN_WEEK)
+    YELLOW = Report('yellow', 'USER AGENT REPORT', '#FFFFF0', YELLOW_REPORT_PORT, DAYS_IN_TWO_WEEKS_REPORT)
 
 
 @dataclass
 class Index:
     index_title: str
     index_name: str
+    days_to_fetch_in_one_go: int
 
 
 class Indexes(Enum):
-    ACCESS = Index('Access-logs', 'ACCESS_INDEX_NAME')
-    INGRESS = Index('Ingress-logs', 'INGRESS_INDEX_NAME')
+    ACCESS = Index('Access-logs', 'ACCESS_INDEX_NAME', DAYS_IN_TWO_WEEKS_REPORT)
+    INGRESS = Index('Ingress-logs', 'INGRESS_INDEX_NAME', DAYS_IN_WEEK)
 
 
 @dataclass


### PR DESCRIPTION
Modified Elastic fetcher
- added index specific length (in days) for indexes, that takes into consideration the amount of documents on that log. 
- modified ElasticFetcher so that it achieves the total duration of the report by repetitive searches of index specific duration, that are merged  together by key (user_agent)