### PR TITLE
temporary fix for pypi downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+#local
+Output
+Reports

--- a/multiversx_usage_analytics_tool/package_managers_fetcher.py
+++ b/multiversx_usage_analytics_tool/package_managers_fetcher.py
@@ -308,7 +308,8 @@ class PackageManagersFetcher(Fetcher):
 
         with tqdm(total=len(packages)) as pbar:
             for package_name in packages:
-                fetched_downloads = result.fetch_pypi_downloads(package_name)
+                # fetched_downloads = result.fetch_pypi_downloads(package_name)
+                fetched_downloads = {}
                 package_downloads = PackageManagersPackage.from_pypi_fetched_data(
                     package_name, Languages.PYTHON.value.lang_name, fetched_downloads)
                 package_downloads.libraries_io_score = result.fetch_libraries_io_score(package_name, PackagesRegistries.PYPI.name)


### PR DESCRIPTION
Since the server pypistats.org is down, downloads data cannot be gathered anymore. 
A possible solution in case the server remains down would be using the pepy.tech api or google big search, but until a decision is taken, downloads statistics for pypi will be temporary disabled. 